### PR TITLE
Fixed admin user_register form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,7 @@
+- 01/11/2011 < Edoardo Tenani >:
+  + forked from https://github.com/danorton/slpjq
+  + fixed bug in slpjq.module, line 170
+    the slpjq_form_user_register_alter() overriding was affecting also the
+    admin/user/user/create form, making impossible to register users via
+    web interface.
+  + added CHANGELOG

--- a/slpjq.info
+++ b/slpjq.info
@@ -12,7 +12,7 @@ core = 6.x
 ;package = "Other"
 dependencies[] = jquery_ui
 
-version = "6.x-1.0-beta3"
+version = "6.x-1.0-beta5"
 core = "6.x"
 project = "slpjq"
 datestamp = "1270591885"

--- a/slpjq.module
+++ b/slpjq.module
@@ -168,9 +168,11 @@ function slpjq_form_user_login_block_alter(&$form, &$form_state) {
  * @see slpjq_form_user_register_validate()
  */
 function slpjq_form_user_register_alter(&$form, &$form_state) {
-  $form['submit']['#value'] = variable_get('slpjq_create_button_text', '');
-  $form['#action'] = url('user/register', array('query' => drupal_get_destination()));
-  $form['#validate'][] = 'slpjq_form_user_register_validate';
+  if ( $form["#action"] != "/admin/user/user/create" ) {
+    $form['submit']['#value'] = variable_get('slpjq_create_button_text', '');
+    $form['#action'] = url('user/register', array('query' => drupal_get_destination()));
+    $form['#validate'][] = 'slpjq_form_user_register_validate';
+  }
 }
 /* @} Hook functions */
 


### PR DESCRIPTION
The <tt>slpjq_form_user_register_alter()</tt> overriding was affecting also the admin/user/user/create form, making impossible to register users via web interface. 

The fix is simply checking if the <tt>#action</tt> of the form is <tt>admin/user/user/create</tt>, in which case skip the content of the function.
